### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: check
         run: cargo check
       - name: examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = [".github"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
     "bevy_ui",
     "bevy_text",
     "bevy_scene",
@@ -22,7 +22,7 @@ bevy = { version = "0.16.0", default-features = false, features = [
 chumsky = "0.9.3"
 
 [dev-dependencies]
-bevy = { version = "0.16.0" }
+bevy = { git = "https://github.com/bevyengine/bevy" }
 
 [lints.rust]
 missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = [".github"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.17.0-rc.1", default-features = false, features = [
     "bevy_ui",
     "bevy_text",
     "bevy_scene",
@@ -22,7 +22,7 @@ bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, f
 chumsky = "0.9.3"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+bevy = { version = "0.17.0-rc.1" }
 
 [lints.rust]
 missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = [".github"]
 
 [dependencies]
-bevy = { version = "0.17.0-rc.1", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "bevy_ui",
     "bevy_text",
     "bevy_scene",
@@ -22,7 +22,7 @@ bevy = { version = "0.17.0-rc.1", default-features = false, features = [
 chumsky = "0.9.3"
 
 [dev-dependencies]
-bevy = { version = "0.17.0-rc.1" }
+bevy = { version = "0.17.0" }
 
 [lints.rust]
 missing_docs = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ fn richtext_changed(world: &mut World) {
                     world
                         .commands()
                         .entity(*style_ent)
-                        .clone_with(span_ent, |builder| {
+                        .clone_with_opt_out(span_ent, |builder| {
                             builder.deny::<(StyleTag, DefaultStyle, ChildOf)>();
                         });
                 }


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_simple_rich_text]
git = "https://github.com/rparrett/bevy_simple_rich_text.git"
branch = "bevy-0.17"
```